### PR TITLE
Syntax fixes for Swift 1.2

### DIFF
--- a/KonamiCode-Bridging-Header.h
+++ b/KonamiCode-Bridging-Header.h
@@ -1,5 +1,0 @@
-//
-//  Use this file to import your target's public headers that you would like to expose to Swift.
-//
-
-#import <UIKit/UIGestureRecognizerSubclass.h>

--- a/PlopixKonamiGesture.swift
+++ b/PlopixKonamiGesture.swift
@@ -8,6 +8,7 @@
 */
 
 import UIKit
+import UIKit.UIGestureRecognizerSubclass
 
 /**
     Allow you to track the KomamiTouchCode

--- a/PlopixKonamiGesture.swift
+++ b/PlopixKonamiGesture.swift
@@ -189,13 +189,13 @@ class PlopixKonamiGesture: UIGestureRecognizer {
     /**
         Touches Began
     */
-    override func touchesBegan(touches: NSSet!, withEvent event: UIEvent!)  {
+    override func touchesBegan(touches: Set<NSObject>!, withEvent event: UIEvent!) {
         if ( event.touchesForGestureRecognizer(self)?.count > 1 ) {
             // give a direct failed when more than touches are detected
             self.state = .Failed;
             return
         }
-        let touch:UITouch = touches.anyObject() as UITouch
+        let touch:UITouch = touches.first as! UITouch
         self.startingPoint = touch.locationInView(self.view)
         if ( self.state == .Changed ) {
             // do nothing now
@@ -213,8 +213,8 @@ class PlopixKonamiGesture: UIGestureRecognizer {
     /**
         Touches Moved
     */
-    override func touchesMoved(touches: NSSet!, withEvent event: UIEvent!) {
-        let touch:UITouch = touches.anyObject() as UITouch
+    override func touchesMoved(touches: Set<NSObject>!, withEvent event: UIEvent!) {
+        let touch:UITouch = touches.first as! UITouch
         if ( !self.isOnHisWay(touch.locationInView(self.view)) ) {
             self.state = .Failed;
         }
@@ -223,8 +223,8 @@ class PlopixKonamiGesture: UIGestureRecognizer {
     /**
         Touches Ended
     */
-    override func touchesEnded(touches: NSSet!, withEvent event: UIEvent!) {
-        let touch:UITouch = touches.anyObject() as UITouch
+    override func touchesEnded(touches: Set<NSObject>!, withEvent event: UIEvent!) {
+        let touch:UITouch = touches.first as! UITouch!
         let endPoint:CGPoint = touch.locationInView(self.view)
         
         if ( self.isOnHisWay(endPoint) && self.hasReachMinDistance(endPoint)  ) {
@@ -244,7 +244,7 @@ class PlopixKonamiGesture: UIGestureRecognizer {
     /**
         Touches Cancelled
     */
-    override func touchesCancelled(touches: NSSet!, withEvent event: UIEvent!) {
+    override func touchesCancelled(touches: Set<NSObject>!, withEvent event: UIEvent!) {
         self.reset()
     }
     

--- a/StandoloneProject/KonamiCode.xcodeproj/project.pbxproj
+++ b/StandoloneProject/KonamiCode.xcodeproj/project.pbxproj
@@ -38,7 +38,6 @@
 		7F6F77AB19F1059E0026F906 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7F6F77AC19F1059E0026F906 /* KonamiCodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KonamiCodeTests.swift; sourceTree = "<group>"; };
 		7F6F77B619F106070026F906 /* PlopixKonamiGesture.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PlopixKonamiGesture.swift; path = ../PlopixKonamiGesture.swift; sourceTree = "<group>"; };
-		7F7E1C6719F244B800F3DDBC /* KonamiCode-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "KonamiCode-Bridging-Header.h"; path = "../KonamiCode-Bridging-Header.h"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -62,7 +61,6 @@
 		7F6F778819F1059E0026F906 = {
 			isa = PBXGroup;
 			children = (
-				7F7E1C6719F244B800F3DDBC /* KonamiCode-Bridging-Header.h */,
 				7F6F77B619F106070026F906 /* PlopixKonamiGesture.swift */,
 				7F6F779319F1059E0026F906 /* KonamiCode */,
 				7F6F77A919F1059E0026F906 /* KonamiCodeTests */,
@@ -346,7 +344,6 @@
 				INFOPLIST_FILE = KonamiCode/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "../KonamiCode-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -359,7 +356,6 @@
 				INFOPLIST_FILE = KonamiCode/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_OBJC_BRIDGING_HEADER = "../KonamiCode-Bridging-Header.h";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Replaced a couple of functions with the Swift 1.2 equivalent. So only minor changes.

Also removed the unneeded bridging header and added it to the import.
This makes it easier to import `PlopixKonamiGesture.swift` file in your project.

Thanks for sharing PlopixKonamiGesture this saved me a couple of hours. 👍🏼